### PR TITLE
Update meta data example to YAML format

### DIFF
--- a/book/src/mod_format.md
+++ b/book/src/mod_format.md
@@ -96,16 +96,17 @@ with an optimal balance of size and decompresison performance.
 
 ### Meta File
 
-Mod metadata is stored in the TOML format under `meta.yml` in the ZIP root. It
+Mod metadata is stored in the YAML format under `meta.yml` in the ZIP root. It
 contains the mod name, description, option information, etc. Example contents:
 
 ```yaml
-name = 'Test Mod'
-version = 1.0
-author = 'Nicene Nerd'
-category = 'Other'
-description = 'A sample UKMM mod'
-platform = 'Wii U'
+name: Test Mod
+version: 1.0.0
+author: Nicene Nerd
+category: Other
+description: A sample UKMM mod
+platform: !Specific Wii U
+url: null
 option_groups = []
 masters = {}
 ```

--- a/book/src/mod_format.md
+++ b/book/src/mod_format.md
@@ -107,8 +107,8 @@ category: Other
 description: A sample UKMM mod
 platform: !Specific Wii U
 url: null
-option_groups = []
-masters = {}
+option_groups: []
+masters: {}
 ```
 
 ### Manifest File


### PR DESCRIPTION
Updates the Mod Format meta data example to match the current build which uses YAML instead of TOML.