### PR TITLE
Fix macOS font loading

### DIFF
--- a/crates/uk-ui/src/lib.rs
+++ b/crates/uk-ui/src/lib.rs
@@ -16,7 +16,7 @@ pub fn load_fonts(context: &egui::Context) {
     let font_to_try = if cfg!(windows) {
         "Segoe UI".to_owned()
     } else if cfg!(target_os = "macos") {
-        "SF Pro".to_owned()
+        "Lucida Grande".to_owned()
     } else {
         std::process::Command::new("gsettings")
             .args(["get", "org.gnome.desktop.interface", "font-name"])


### PR DESCRIPTION
More work for #7. With this, ukmm should compile and run on macOS. I haven't tried loading any mods yet, though, so I don't know if there will be any errors when doing so.

The [previous commit](https://github.com/NiceneNerd/ukmm/commit/512b24e6d795a686fbe5061caf6f8d9327047c46) sets the macOS font to the system UI font SF Pro. However, this font is not available to users by default and has to be installed [from Apple](https://developer.apple.com/fonts/), so results in errors like this if not installed:
```
thread 'main' panicked at 'No font data found for "System"', /Users/neeby/.cargo/git/checkouts/egui-e93c8b2747e99fbf/3803a32/crates/epaint/src/text/fonts.rs:748:32
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
An unrecoverable error occured. Error details: No font data found for "System"
``` 

Among the default fonts available on macOS are the previous UI font Helvetica Neue and the original Mac OS X system UI font Lucida Grande. I chose the latter as it's slightly wider and I think that'd be easier to read.