### PR TITLE
Set macOS deployment target in release wf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         run: cargo +nightly-2023-02-28 build --release
         env:
           UPDATE_PLATFORM: ${{ matrix.platform.name }}
+          MACOSX_DEPLOYMENT_TARGET: 11.0
       - name: UPX compress binary
         uses: crazy-max/ghaction-upx@v2.2.0
         if: contains(matrix.platform.os, 'ubuntu')


### PR DESCRIPTION
See #93. 
Sets the `MACOSX_DEPLOYMENT_TARGET` environment variable in `release.yml` to 11.0 to support macOS 11 in the GitHub release executable. Otherwise, when the variable is not set, rust seems set the minimum deployment to whatever version of macOS it is compiled on, and the GitHub runners use `macos-latest`, which GitHub has set to macOS 12. To my knowledge this environment variable should only affect the macOS build, so it was easier to set the variable for all platforms than conditionally set it for macOS only. I can update this PR to do the latter if preferred.

I tested this action by creating a [release](https://github.com/neebyA/ukmm/releases/tag/v0.7.1) on my fork, and inspecting the generated object file
Before:
```
otool -l ukmm | rg LC_BUILD_VERSION -A4
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 12.0
      sdk 13.1
```
After:
```
otool -l ukmm | rg LC_BUILD_VERSION -A4
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 11.0
      sdk 13.1
```
It seems like it *should* work on macOS 11, though I haven't actually tried running it on macOS 11 as I don't have that OS version installed on any computer