### PR TITLE
CookData in-depth validator

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
               - 'src/**'
               - 'Cargo.*'
               - 'build.rs'
-              - 'uk-*/**'
+              - 'crates/**'
 
   build_and_test:
     needs: check_changes

--- a/crates/uk-content/src/cooking/mod.rs
+++ b/crates/uk-content/src/cooking/mod.rs
@@ -1,1 +1,4 @@
 pub mod data;
+mod recipe;
+mod single_recipe;
+mod system;

--- a/crates/uk-content/src/cooking/recipe.rs
+++ b/crates/uk-content/src/cooking/recipe.rs
@@ -1,0 +1,165 @@
+use anyhow::Context;
+use roead::byml::Byml;
+use serde::{Deserialize, Serialize};
+use smartstring::{SmartString, LazyCompact};
+#[cfg(feature = "ui")]
+use uk_ui_derive::Editable;
+
+use crate::{
+    util::{DeleteVec, HashMap},
+    Result, UKError
+};
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ui", derive(Editable))]
+pub struct Recipe {
+    pub actors: Option<DeleteVec<DeleteVec<i32>>>,
+    pub hb: Option<i32>,
+    pub recipe: i32,
+    pub tags: Option<DeleteVec<DeleteVec<i32>>>,
+}
+
+impl TryFrom<&Byml> for Recipe {
+    type Error = UKError;
+
+    fn try_from(byml: &Byml) -> Result<Self> {
+        let hash = byml.as_hash()?;
+        Ok(Self {
+            actors: hash
+                .get("Actors")
+                .map_or(
+                    None,
+                    |arr| {
+                        Some(arr.as_array()
+                            .map_err(|_e| UKError::WrongBymlType(
+                                "not an array of arrays".into(),
+                                "an array of arrays"
+                            ))
+                            .unwrap()
+                            .iter()
+                            .map(|arr2| {
+                                arr2.as_array()
+                                    .map_err(|_e| UKError::WrongBymlType(
+                                        "not an array".into(),
+                                        "an array"
+                                    ))
+                                    .unwrap()
+                                    .iter()
+                                    .map(|i| {
+                                        i.as_i32()
+                                            .map_err(|_e| UKError::WrongBymlType(
+                                                "not an integer".into(),
+                                                "an integer"
+                                            ))
+                                            .unwrap()
+                                    })
+                                    .collect::<DeleteVec<i32>>()
+                            })
+                            .collect::<DeleteVec<DeleteVec<i32>>>()
+                        )
+                    }
+                ),
+            hb: hash
+                .get("HB")
+                .map_or(
+                    None,
+                    |i| Some(i.as_i32().context("HB not int").unwrap())
+                ),
+            recipe: hash
+                .get("Recipe")
+                .ok_or(UKError::MissingBymlKey("Recipe missing recipe actor"))?
+                .as_i32()
+                .map_err(|_e| {
+                    UKError::WrongBymlType("not an integer".into(), "an integer")
+                })
+                .unwrap(),
+            tags: hash
+                .get("Tags")
+                .map_or(
+                    None,
+                    |arr| {
+                        Some(arr.as_array()
+                            .map_err(|_e| UKError::WrongBymlType(
+                                "not an array of arrays".into(),
+                                "an array of arrays"
+                            ))
+                            .unwrap()
+                            .iter()
+                            .map(|arr2| {
+                                arr2.as_array()
+                                    .map_err(|_e| UKError::WrongBymlType(
+                                        "not an array".into(),
+                                        "an array"
+                                    ))
+                                    .unwrap()
+                                    .iter()
+                                    .map(|i| {
+                                        i.as_i32()
+                                            .map_err(|_e| UKError::WrongBymlType(
+                                                "not an integer".into(),
+                                                "an integer"
+                                            ))
+                                            .unwrap()
+                                    })
+                                    .collect::<DeleteVec<i32>>()
+                            })
+                            .collect::<DeleteVec<DeleteVec<i32>>>()
+                        )
+                    }
+                ),
+        })
+    }
+}
+
+impl From<&Recipe> for Byml {
+    fn from(val: &Recipe) -> Byml {
+        let mut hash: HashMap<SmartString<LazyCompact>, Byml> = HashMap::default();
+        if let Some(actors) = &val.actors {
+            hash.insert(
+                "Actors".into(),
+                actors.iter()
+                    .map(|v| {
+                        v.iter()
+                            .map(|v2| {
+                                if *v2 < 0 {
+                                    Byml::U32(*v2 as u32)
+                                }
+                                else {
+                                    Byml::I32(*v2)
+                                }
+                            })
+                            .collect::<Vec<Byml>>()
+                            .into()
+                    })
+                    .collect::<Vec<Byml>>()
+                    .into()
+            );
+        }
+        if let Some(hb) = val.hb {
+            hash.insert("HB".into(), hb.into());
+        };
+        hash.insert("Recipe".into(), val.recipe.into());
+        if let Some(tags) = &val.tags {
+            hash.insert(
+                "Tags".into(),
+                tags.iter()
+                    .map(|v| {
+                        v.iter()
+                            .map(|v2| {
+                                if *v2 < 0 {
+                                    Byml::U32(*v2 as u32)
+                                }
+                                else {
+                                    Byml::I32(*v2)
+                                }
+                            })
+                            .collect::<Vec<Byml>>()
+                            .into()
+                    })
+                    .collect::<Vec<Byml>>()
+                    .into()
+            );
+        }
+        hash.into()
+    }
+}

--- a/crates/uk-content/src/cooking/recipe.rs
+++ b/crates/uk-content/src/cooking/recipe.rs
@@ -46,7 +46,7 @@ impl TryFrom<&Byml> for Recipe {
                                     .unwrap()
                                     .iter()
                                     .map(|i| {
-                                        i.as_i32()
+                                        i.as_int::<i32>()
                                             .map_err(|_e| UKError::WrongBymlType(
                                                 "not an integer".into(),
                                                 "an integer"
@@ -68,7 +68,7 @@ impl TryFrom<&Byml> for Recipe {
             recipe: hash
                 .get("Recipe")
                 .ok_or(UKError::MissingBymlKey("Recipe missing recipe actor"))?
-                .as_i32()
+                .as_int::<i32>()
                 .map_err(|_e| {
                     UKError::WrongBymlType("not an integer".into(), "an integer")
                 })
@@ -94,7 +94,7 @@ impl TryFrom<&Byml> for Recipe {
                                     .unwrap()
                                     .iter()
                                     .map(|i| {
-                                        i.as_i32()
+                                        i.as_int::<i32>()
                                             .map_err(|_e| UKError::WrongBymlType(
                                                 "not an integer".into(),
                                                 "an integer"

--- a/crates/uk-content/src/cooking/single_recipe.rs
+++ b/crates/uk-content/src/cooking/single_recipe.rs
@@ -122,6 +122,7 @@ impl From<&SingleRecipe> for Byml {
         if let Some(hb) = val.hb {
             hash.insert("HB".into(), hb.into());
         };
+        hash.insert("Num".into(), val.num.into());
         hash.insert("Recipe".into(), val.recipe.into());
         if let Some(tags) = &val.tags {
             hash.insert(

--- a/crates/uk-content/src/cooking/single_recipe.rs
+++ b/crates/uk-content/src/cooking/single_recipe.rs
@@ -1,0 +1,144 @@
+use anyhow::Context;
+use roead::byml::Byml;
+use serde::{Deserialize, Serialize};
+use smartstring::{SmartString, LazyCompact};
+#[cfg(feature = "ui")]
+use uk_ui_derive::Editable;
+
+use crate::{
+    util::{DeleteVec, HashMap},
+    Result, UKError
+};
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ui", derive(Editable))]
+pub struct SingleRecipe {
+    pub actors: Option<DeleteVec<i32>>,
+    pub hb: Option<i32>,
+    pub num: i32,
+    pub recipe: i32,
+    pub tags: Option<DeleteVec<i32>>,
+}
+
+impl TryFrom<&Byml> for SingleRecipe {
+    type Error = UKError;
+
+    fn try_from(byml: &Byml) -> Result<Self> {
+        let hash = byml.as_hash()?;
+        Ok(Self {
+            actors: hash
+                .get("Actors")
+                .map_or(
+                    None,
+                    |arr| {
+                        Some(arr.as_array()
+                            .map_err(|_e| UKError::WrongBymlType(
+                                "not an array".into(),
+                                "an array"
+                            ))
+                            .unwrap()
+                            .iter()
+                            .map(|i| {
+                                i.as_i32()
+                                    .map_err(|_e| UKError::WrongBymlType(
+                                        "not an integer".into(),
+                                        "an integer"
+                                    ))
+                                    .unwrap()
+                            })
+                            .collect::<DeleteVec<i32>>()
+                        )
+                    }
+                ),
+            hb: hash
+                .get("HB")
+                .map_or(
+                    None,
+                    |i| Some(i.as_i32().context("HB not int").unwrap())
+                ),
+            num: hash
+                .get("Num")
+                .ok_or(UKError::MissingBymlKey("Recipe missing num"))?
+                .as_i32()
+                .map_err(|_e| {
+                    UKError::WrongBymlType("not an integer".into(), "an integer")
+                })
+                .unwrap(),
+            recipe: hash
+                .get("Recipe")
+                .ok_or(UKError::MissingBymlKey("Recipe missing recipe actor"))?
+                .as_i32()
+                .map_err(|_e| {
+                    UKError::WrongBymlType("not an integer".into(), "an integer")
+                })
+                .unwrap(),
+            tags: hash
+                .get("Tags")
+                .map_or(
+                    None,
+                    |arr| {
+                        Some(arr.as_array()
+                            .map_err(|_e| UKError::WrongBymlType(
+                                "not an array".into(),
+                                "an array"
+                            ))
+                            .unwrap()
+                            .iter()
+                            .map(|i| {
+                                i.as_i32()
+                                    .map_err(|_e| UKError::WrongBymlType(
+                                        "not an integer".into(),
+                                        "an integer"
+                                    ))
+                                    .unwrap()
+                            })
+                            .collect::<DeleteVec<i32>>()
+                        )
+                    }
+                ),
+        })
+    }
+}
+
+impl From<&SingleRecipe> for Byml {
+    fn from(val: &SingleRecipe) -> Byml {
+        let mut hash: HashMap<SmartString<LazyCompact>, Byml> = HashMap::default();
+        if let Some(actors) = &val.actors {
+            hash.insert(
+                "Actors".into(),
+                actors.iter()
+                    .map(|v| {
+                        if *v < 0 {
+                            Byml::U32(*v as u32)
+                        }
+                        else {
+                            Byml::I32(*v)
+                        }
+                    })
+                    .collect::<Vec<Byml>>()
+                    .into()
+            );
+        }
+        if let Some(hb) = val.hb {
+            hash.insert("HB".into(), hb.into());
+        };
+        hash.insert("Recipe".into(), val.recipe.into());
+        if let Some(tags) = &val.tags {
+            hash.insert(
+                "Tags".into(),
+                tags.iter()
+                    .map(|v| {
+                        if *v < 0 {
+                            Byml::U32(*v as u32)
+                        }
+                        else {
+                            Byml::I32(*v)
+                        }
+                    })
+                    .collect::<Vec<Byml>>()
+                    .into()
+            );
+        }
+        hash.into()
+    }
+}

--- a/crates/uk-content/src/cooking/single_recipe.rs
+++ b/crates/uk-content/src/cooking/single_recipe.rs
@@ -39,7 +39,7 @@ impl TryFrom<&Byml> for SingleRecipe {
                             .unwrap()
                             .iter()
                             .map(|i| {
-                                i.as_i32()
+                                i.as_int::<i32>()
                                     .map_err(|_e| UKError::WrongBymlType(
                                         "not an integer".into(),
                                         "an integer"
@@ -58,7 +58,7 @@ impl TryFrom<&Byml> for SingleRecipe {
                 ),
             num: hash
                 .get("Num")
-                .ok_or(UKError::MissingBymlKey("Recipe missing num"))?
+                .ok_or(UKError::MissingBymlKey("SingleRecipe missing num"))?
                 .as_i32()
                 .map_err(|_e| {
                     UKError::WrongBymlType("not an integer".into(), "an integer")
@@ -66,8 +66,8 @@ impl TryFrom<&Byml> for SingleRecipe {
                 .unwrap(),
             recipe: hash
                 .get("Recipe")
-                .ok_or(UKError::MissingBymlKey("Recipe missing recipe actor"))?
-                .as_i32()
+                .ok_or(UKError::MissingBymlKey("SingleRecipe missing recipe actor"))?
+                .as_int::<i32>()
                 .map_err(|_e| {
                     UKError::WrongBymlType("not an integer".into(), "an integer")
                 })
@@ -85,7 +85,7 @@ impl TryFrom<&Byml> for SingleRecipe {
                             .unwrap()
                             .iter()
                             .map(|i| {
-                                i.as_i32()
+                                i.as_int::<i32>()
                                     .map_err(|_e| UKError::WrongBymlType(
                                         "not an integer".into(),
                                         "an integer"

--- a/crates/uk-content/src/cooking/system.rs
+++ b/crates/uk-content/src/cooking/system.rs
@@ -1,0 +1,300 @@
+use anyhow::Context;
+use roead::byml::Byml;
+use serde::{Deserialize, Serialize};
+use smartstring::{SmartString, LazyCompact};
+#[cfg(feature = "ui")]
+use uk_ui_derive::Editable;
+
+use crate::{
+    prelude::Mergeable,
+    util::{bhash, DeleteVec},
+    Result, UKError
+};
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ui", derive(Editable))]
+pub struct System {
+    pub cei: DeleteVec<CEI>,
+    pub fa: SmartString<LazyCompact>,
+    pub falr: i32,
+    pub falrmr: f32,
+    pub fca: SmartString<LazyCompact>,
+    pub lrmr: f32,
+    pub mea: SmartString<LazyCompact>,
+    pub nmmr: DeleteVec<f32>,
+    pub nmssr: DeleteVec<i32>,
+    pub sfalr: i32,
+    pub ssaet: i32
+}
+
+impl TryFrom<&Byml> for System {
+    type Error = UKError;
+
+    fn try_from(byml: &Byml) -> Result<Self> {
+        let hash = byml.as_hash()?;
+        Ok(Self {
+            cei: hash
+                .get("CEI")
+                .ok_or(UKError::MissingBymlKey("System missing CEI"))?
+                .as_array()
+                .map_err(|_| UKError::WrongBymlType("not an array".into(), "an array"))?
+                .iter()
+                .map(|b| {
+                    CEI::try_from(b)
+                        .context("Failed to parse CEI")
+                        .unwrap()
+                })
+                .collect(),
+            fa: hash
+                .get("FA")
+                .ok_or(UKError::MissingBymlKey("System missing FA"))?
+                .as_string()
+                .map_err(|_| {
+                    UKError::WrongBymlType("not a string".into(), "a string")
+                })
+                .unwrap()
+                .clone(),
+            falr: hash
+                .get("FALR")
+                .ok_or(UKError::MissingBymlKey("System missing FALR"))?
+                .as_i32()
+                .map_err(|_| {
+                    UKError::WrongBymlType("not an integer".into(), "an integer")
+                })
+                .unwrap(),
+            falrmr: hash
+                .get("FALRMR")
+                .ok_or(UKError::MissingBymlKey("System missing FALRMR"))?
+                .as_float()
+                .map_err(|_| {
+                    UKError::WrongBymlType("not a float".into(), "a float")
+                })
+                .unwrap(),
+            fca: hash
+                .get("FCA")
+                .ok_or(UKError::MissingBymlKey("System missing FCA"))?
+                .as_string()
+                .map_err(|_| {
+                    UKError::WrongBymlType("not a string".into(), "a string")
+                })
+                .unwrap()
+                .clone(),
+            lrmr: hash
+                .get("LRMR")
+                .ok_or(UKError::MissingBymlKey("System missing LRMR"))?
+                .as_float()
+                .map_err(|_| {
+                    UKError::WrongBymlType("not a float".into(), "a float")
+                })
+                .unwrap(),
+            mea: hash
+                .get("MEA")
+                .ok_or(UKError::MissingBymlKey("System missing MEA"))?
+                .as_string()
+                .map_err(|_| {
+                    UKError::WrongBymlType("not a string".into(), "a string")
+                })
+                .unwrap()
+                .clone(),
+            nmmr: hash
+                .get("NMMR")
+                .ok_or(UKError::MissingBymlKey("System missing NMMR"))?
+                .as_array()
+                .map_err(|_| UKError::WrongBymlType("not an array".into(), "an array"))?
+                .iter()
+                .map(|b| {
+                    b.as_float()
+                    .map_err(|_| UKError::WrongBymlType(
+                        "not a float".into(),
+                        "a float"
+                    ))
+                    .unwrap()
+                })
+                .collect(),
+            nmssr: hash
+                .get("NMSSR")
+                .ok_or(UKError::MissingBymlKey("System missing NMSSR"))?
+                .as_array()
+                .map_err(|_| UKError::WrongBymlType("not an array".into(), "an array"))?
+                .iter()
+                .map(|b| {
+                    b.as_i32()
+                        .map_err(|_| UKError::WrongBymlType(
+                            "not an integer".into(),
+                            "an integer"
+                        ))
+                        .unwrap()
+                })
+                .collect(),
+            sfalr: hash
+                .get("SFALR")
+                .ok_or(UKError::MissingBymlKey("System missing SFALR"))?
+                .as_i32()
+                .map_err(|_| {
+                    UKError::WrongBymlType("not an integer".into(), "an integer")
+                })
+                .unwrap(),
+            ssaet: hash
+                .get("SSAET")
+                .ok_or(UKError::MissingBymlKey("System missing SSAET"))?
+                .as_i32()
+                .map_err(|_| {
+                    UKError::WrongBymlType("not an integer".into(), "an integer")
+                })
+                .unwrap(),
+        })
+    }
+}
+
+impl From<System> for Byml {
+    fn from(val: System) -> Byml {
+        bhash!{
+            "CEI" => val.cei.iter().map(|c| Byml::from(c)).collect(),
+            "FA" => val.fa.clone().into(),
+            "FALR" => val.falr.into(),
+            "FALRMR" => val.falrmr.into(),
+            "FCA" => val.fca.clone().into(),
+            "LRMR" => val.lrmr.into(),
+            "MEA" => val.mea.clone().into(),
+            "NMMR" => val.nmmr.iter().map(|n| Byml::Float(*n)).collect(),
+            "NMSSR" => val.nmssr.iter().map(|n| Byml::I32(*n)).collect(),
+            "SFALR" => val.sfalr.into(),
+            "SSAET" => val.ssaet.into(),
+        }
+    }
+}
+
+impl Mergeable for System {
+    fn diff(&self, other: &Self) -> Self {
+        Self {
+            cei: self.cei.diff(&other.cei),
+            fa: other.fa.clone(),
+            falr: other.falr,
+            falrmr: other.falrmr,
+            fca: other.fca.clone(),
+            lrmr: other.lrmr,
+            mea: other.mea.clone(),
+            nmmr: self.nmmr.diff(&other.nmmr),
+            nmssr: self.nmssr.diff(&other.nmssr),
+            sfalr: other.sfalr,
+            ssaet: other.ssaet,
+        }
+    }
+
+    fn merge(&self, diff: &Self) -> Self {
+        Self {
+            cei: self.cei.merge(&diff.cei),
+            fa: diff.fa.clone(),
+            falr: diff.falr,
+            falrmr: diff.falrmr,
+            fca: diff.fca.clone(),
+            lrmr: diff.lrmr,
+            mea: diff.mea.clone(),
+            nmmr: self.nmmr.merge(&diff.nmmr),
+            nmssr: self.nmssr.merge(&diff.nmssr),
+            sfalr: diff.sfalr,
+            ssaet: diff.ssaet,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ui", derive(Editable))]
+pub struct CEI {
+    bt: i32,
+    mr: f32,
+    ma: i32,
+    mi: i32,
+    ssa: i32,
+    t: i32
+}
+
+impl TryFrom<&Byml> for CEI {
+    type Error = UKError;
+
+    fn try_from(byml: &Byml) -> Result<Self> {
+        let hash = byml.as_hash()?;
+        Ok(Self {
+            bt: hash
+                .get("BT")
+                .ok_or(UKError::MissingBymlKey("CEI missing BT"))?
+                .as_i32()
+                .map_err(|_| UKError::WrongBymlType("not an integer".into(), "an integer"))
+                .unwrap(),
+            mr: hash
+                .get("MR")
+                .ok_or(UKError::MissingBymlKey("CEI missing MR"))?
+                .as_float()
+                .map_err(|_| UKError::WrongBymlType("not a float".into(), "a float"))
+                .unwrap(),
+            ma: hash
+                .get("BT")
+                .ok_or(UKError::MissingBymlKey("CEI missing MA"))?
+                .as_i32()
+                .map_err(|_| UKError::WrongBymlType("not an integer".into(), "an integer"))
+                .unwrap(),
+            mi: hash
+                .get("BT")
+                .ok_or(UKError::MissingBymlKey("CEI missing MI"))?
+                .as_i32()
+                .map_err(|_| UKError::WrongBymlType("not an integer".into(), "an integer"))
+                .unwrap(),
+            ssa: hash
+                .get("BT")
+                .ok_or(UKError::MissingBymlKey("CEI missing SSA"))?
+                .as_i32()
+                .map_err(|_| UKError::WrongBymlType("not an integer".into(), "an integer"))
+                .unwrap(),
+            t: hash
+                .get("BT")
+                .ok_or(UKError::MissingBymlKey("CEI missing T"))?
+                .as_i32()
+                .map_err(|_| UKError::WrongBymlType("not an integer".into(), "an integer"))
+                .unwrap(),
+        })
+    }
+}
+
+impl From<&CEI> for Byml {
+    fn from(val: &CEI) -> Byml {
+        bhash!{
+            "BT" => val.bt.into(),
+            "MR" => val.mr.into(),
+            "MA" => val.ma.into(),
+            "MI" => val.mi.into(),
+            "SSA" => val.ssa.into(),
+            "T" => {
+                if val.t < 0 {
+                    Byml::U32(val.t as u32)
+                }
+                else {
+                    Byml::I32(val.t)
+                }
+            },
+        }
+    }
+}
+
+impl Mergeable for CEI {
+    fn diff(&self, other: &Self) -> Self {
+        Self {
+            bt: other.bt,
+            mr: other.mr,
+            ma: other.ma,
+            mi: other.mi,
+            ssa: other.ssa,
+            t: other.t,
+        }
+    }
+
+    fn merge(&self, diff: &Self) -> Self {
+        Self {
+            bt: diff.bt,
+            mr: diff.mr,
+            ma: diff.ma,
+            mi: diff.mi,
+            ssa: diff.ssa,
+            t: diff.t,
+        }
+    }
+}

--- a/crates/uk-content/src/cooking/system.rs
+++ b/crates/uk-content/src/cooking/system.rs
@@ -248,7 +248,7 @@ impl TryFrom<&Byml> for CEI {
             t: hash
                 .get("BT")
                 .ok_or(UKError::MissingBymlKey("CEI missing T"))?
-                .as_i32()
+                .as_int::<i32>()
                 .map_err(|_| UKError::WrongBymlType("not an integer".into(), "an integer"))
                 .unwrap(),
         })


### PR DESCRIPTION
Validates CookData by parsing all fields into immutable types.

Currently uses DeleteVec and its Mergeable impl for diffing/merging Recipes and SingleRecipes, which means the entire Recipe/SingleRecipe gets cloned into the diff/merged. This is inefficient for both storage and merging, compared to using straight Byml, but is more secure.

This is basically hitting the CookData merging problem with a nuke, and is what I was able to come up with without analyzing other Byml-type mergers in-depth to figure out exactly why CookData was behaving differently. You may wish to use a less computationally-intensive solution.