### PR TITLE
Cemu experimental path support

### DIFF
--- a/src/gui/tasks.rs
+++ b/src/gui/tasks.rs
@@ -357,6 +357,12 @@ pub fn import_cemu_settings(core: &Manager, path: &Path) -> Result<Message> {
         .ok_or_else(|| anyhow::anyhow!("Could not find game dump from Cemu settings"))?;
     let gfx_folder = if let Some(path) = path.with_file_name("graphicPacks").exists_then() {
         path
+    } else if let Some(path) = dirs2::config_dir()
+        .expect("YIKES")
+        .join("Cemu/graphicPacks")
+        .exists_then()
+    {
+        path
     } else if let Some(path) = dirs2::data_local_dir()
         .expect("YIKES")
         .join("Cemu/graphicPacks")


### PR DESCRIPTION
Addresses, closes #192 

Switches gfx_folder from Option\<PathBuf> to PathBuf because @JaimieVandenbergh has confirmed that the graphics pack folder will be read by Cemu from the same path as settings.xml, so if it's nowhere else then we can create it there and Cemu will read from it as if it had created it, itself.