### PR TITLE
Fix partial language merging

### DIFF
--- a/crates/uk-manager/src/mods.rs
+++ b/crates/uk-manager/src/mods.rs
@@ -318,10 +318,14 @@ impl Manager {
         self.mods().filter(|mod_| {
             match mod_.manifest() {
                 Ok(manifest) => {
-                    !ref_manifest
-                        .content_files
-                        .is_disjoint(&manifest.content_files)
+                    let languages = manifest.languages();
+                    !ref_manifest.content_files.is_disjoint(&manifest.content_files)
                         || !ref_manifest.aoc_files.is_disjoint(&manifest.aoc_files)
+                        || (
+                            ref_manifest.languages()
+                                .iter()
+                                .any(|l| languages.contains(l))
+                        )
                 }
                 Err(_) => false,
             }

--- a/crates/uk-mod/src/lib.rs
+++ b/crates/uk-mod/src/lib.rs
@@ -8,8 +8,7 @@ use anyhow_ext::Context;
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String;
 use uk_content::{
-    prelude::Endian,
-    util::{HashSet, IndexMap},
+    constants::Language, prelude::Endian, util::{HashSet, IndexMap}
 };
 pub mod pack;
 pub mod unpack;
@@ -26,6 +25,19 @@ pub struct Manifest {
 }
 
 impl Manifest {
+    pub fn languages(&self) -> Vec<Language> {
+        self.content_files
+            .iter()
+            .filter_map(|file| {
+                if let Some(lang) = Language::from_path(Path::new(file.as_str())) {
+                    Some(lang)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+
     pub fn resources(&self) -> impl Iterator<Item = String> + '_ {
         self.content_files
             .iter()

--- a/crates/uk-mod/src/unpack.rs
+++ b/crates/uk-mod/src/unpack.rs
@@ -537,10 +537,9 @@ impl ModUnpacker {
                 .collect();
         }
         let mut modded_langs: IndexSet<Language> = Default::default();
-        for lang in Language::iter() {
-            if content_files.remove(&lang.bootup_path()) {
-                modded_langs.insert(*lang);
-            }
+        for lang in self.mods.iter().flat_map(|m| m.manifest.languages()) {
+            modded_langs.insert(lang);
+            content_files.remove(&lang.bootup_path());
         }
         let (content, aoc) = platform_prefixes(self.endian);
         let total = content_files.len() + aoc_files.len();


### PR DESCRIPTION
Manifest filter includes other languages
Unpacker unpacks all languages from mods to be merged

The ModUnpacker changes are a bit of a hammer. A more elegant fix would probably be to assign each mod to only unpack the language it's going to be applying to the merge.

However, it looked to me like the code is merging *all* of the language packs, in order of ascending proximity to the language chosen in the settings. I take that to mean we're accounting for mods that are missing localization in some languages, and that my hammer is the proper fix.

If you think I should limit it to each mod's language nearest to the target, then I can amend this for that behavior.

Tested with 31 mods, including Second Wind, Zelda Dialogue and Cutscene Audio Adjustments, and several mods that add new armor sets to EUen and USen (but not both).