### PR TITLE
Switch folder preserve

### DIFF
--- a/crates/uk-manager/src/deploy.rs
+++ b/crates/uk-manager/src/deploy.rs
@@ -227,7 +227,7 @@ impl Manager {
                     std::fs::create_dir_all(&config.output)
                         .context("Output dir does not exist and could not be created")?;
                 }
-                if !is_symlink(&base_path) || !is_symlink(dlc_path) {
+                if !is_symlink(base_path) || !is_symlink(dlc_path) {
                     if !is_symlink(base_path) {
                         if base_path.exists() {
                             log::warn!("Removing old stuff from base game deploy folder");


### PR DESCRIPTION
Since both @HGStone and @ilonachan have given me evidence that people use switch emulator setups where all title ids are placed in the same folder (as opposed to the mod package setups that ukmm is currently set up for) I made this to preserve the output folder in switch symlink mode, instead symlinking the two title id folders.

Will certainly conflict with the fix I'm making for #199, so I'm drafting this until either that one's done or you decide this isn't necessary.

Currently no testing done, as I don't have the Switch version of the game on emulator. Will need others to test this one for me.