### PR TITLE
Only add Unit list if there are unit objects

### DIFF
--- a/crates/uk-content/src/actor/params/modellist.rs
+++ b/crates/uk-content/src/actor/params/modellist.rs
@@ -67,12 +67,13 @@ impl TryFrom<&ParameterList> for ModelData {
 
 impl From<ModelData> for ParameterList {
     fn from(val: ModelData) -> Self {
-        ParameterList::new()
+        let data = ParameterList::new()
             .with_object(
                 "Base",
                 ParameterObject::new().with_parameter("Folder", val.folder.into()),
-            )
-            .with_list(
+            );
+        if val.units.len() > 0 {
+            data.with_list(
                 "Unit",
                 ParameterList::new().with_objects(val.units.into_iter().enumerate().map(
                     |(i, (name, bone))| {
@@ -85,6 +86,9 @@ impl From<ModelData> for ParameterList {
                     },
                 )),
             )
+        } else {
+            data
+        }
     }
 }
 


### PR DESCRIPTION
Matches vanilla behavior, streamlines file sizes a little bit

Game parser gets the Unit list, then moves on if it's a null pointer. If it's not, it iterates over the objects in that list. So either way, the game does essentially the same thing, but this saves a few bytes in file sizes, a few nanoseconds of parse time, and most importantly it makes the data match up with BCML's output, so if you're comparing two mods programmatically, you don't get false positives from an empty Unit list.