### PR TITLE
Speed up manifest comparison

### DIFF
--- a/crates/uk-manager/src/mods.rs
+++ b/crates/uk-manager/src/mods.rs
@@ -315,14 +315,15 @@ impl Manager {
         &'a self,
         ref_manifest: &'m Manifest,
     ) -> impl Iterator<Item = Mod> + 'm {
-        self.mods().filter(|mod_| {
+        let ref_languages = ref_manifest.languages();
+        self.mods().filter(move |mod_| {
             match mod_.manifest() {
                 Ok(manifest) => {
                     let languages = manifest.languages();
                     !ref_manifest.content_files.is_disjoint(&manifest.content_files)
                         || !ref_manifest.aoc_files.is_disjoint(&manifest.aoc_files)
                         || (
-                            ref_manifest.languages()
+                            ref_languages
                                 .iter()
                                 .any(|l| languages.contains(l))
                         )


### PR DESCRIPTION
Don't iterate files for each other mod, keep the list around for future iterations