### PR TITLE
Fix duplicate bnp options

### DIFF
--- a/crates/uk-mod/src/pack.rs
+++ b/crates/uk-mod/src/pack.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashSet},
     io::Write,
     path::{Path, PathBuf},
     sync::{atomic::AtomicUsize, Arc, LazyLock},
@@ -634,12 +634,12 @@ impl ModPacker {
 
     fn collect_roots(&self) -> Vec<PathBuf> {
         let opt_root = self.source_dir.join("options");
-        let mut roots = Vec::new();
+        let mut roots = HashSet::new();
         for group in &self.meta.options {
             roots.extend(group.options().iter().map(|opt| opt_root.join(&opt.path)))
         }
         log::debug!("Detected options:\n{:#?}", &roots);
-        roots
+        roots.into_iter().collect()
     }
 
     fn pack_thumbnail(&self) -> Result<()> {


### PR DESCRIPTION
Only collect a single instance of each option path, in case the bnp has multiple references to the same path for different options

Fixes mods that used the hack where a None option could be defined, pointing at the options root folder, to ensure no files would be installed if the user selected that option.

Small side effect in that the None option might appear multiple times in each group where it appears, but they all do what is expected of them, so it's a minor inconvenience.