### PR TITLE
Fix file copying on Windows and installation by rules.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,17 +1451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dircpy"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015cf520d424257fb8fbeccda4ee8d921b02907ae612484f036fa1a432b9036e"
-dependencies = [
- "jwalk",
- "log",
- "walkdir",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5353,7 +5342,6 @@ dependencies = [
  "anyhow",
  "anyhow_ext",
  "dashmap",
- "dircpy",
  "dirs2",
  "fs-err",
  "join_str",
@@ -5480,7 +5468,6 @@ dependencies = [
  "anyhow",
  "anyhow_ext",
  "astrolabe",
- "dircpy",
  "dirs2",
  "eframe",
  "egui-notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ product-icon = "assets/ukmm.ico"
 [dependencies]
 anyhow = { workspace = true }
 anyhow_ext = { workspace = true }
-dircpy = { workspace = true }
 dirs2 = { workspace = true }
 eframe = { workspace = true, features = ["glow"] }
 env_logger = "0.11.3"
@@ -92,7 +91,6 @@ version = "0.15.0"
 anyhow = "1"
 anyhow_ext = "0.2.1"
 dashmap = "6"
-dircpy = "0.3.12"
 dirs2 = "3"
 eframe = { version = "0.28", default-features = false }
 flume = "0.11.0"

--- a/crates/uk-manager/Cargo.toml
+++ b/crates/uk-manager/Cargo.toml
@@ -8,7 +8,6 @@ version.workspace = true
 anyhow = { workspace = true }
 anyhow_ext = { workspace = true }
 dashmap = { workspace = true, features = ["rayon"] }
-dircpy = { workspace = true }
 dirs2 = { workspace = true }
 fs-err = { workspace = true }
 join_str = { workspace = true }

--- a/crates/uk-manager/src/bnp.rs
+++ b/crates/uk-manager/src/bnp.rs
@@ -482,7 +482,8 @@ impl BnpConverter {
 pub fn unpack_bnp(core: &crate::core::Manager, path: &Path) -> Result<PathBuf> {
     let tempdir = crate::util::get_temp_folder();
     if path.is_dir() {
-        dircpy::copy_dir(path, tempdir.as_path()).context("Failed to copy files to temp folder")?;
+        crate::util::copy_dir(path, tempdir.as_path())
+            .context("Failed to copy files to temp folder")?;
     } else {
         log::info!("Extracting BNP…");
         extract_7z(path, &tempdir).context("Failed to extract BNP")?;

--- a/crates/uk-manager/src/mods.rs
+++ b/crates/uk-manager/src/mods.rs
@@ -374,7 +374,7 @@ impl Manager {
             if mod_path.is_file() {
                 fs::copy(mod_path, &stored_path).context("Failed to copy mod to storage folder")?;
             } else {
-                dircpy::copy_dir(mod_path, &stored_path)
+                util::copy_dir(mod_path, &stored_path)
                     .context("Failed to copy mod to storage folder")?;
             }
         }

--- a/crates/uk-manager/src/util.rs
+++ b/crates/uk-manager/src/util.rs
@@ -12,7 +12,7 @@ pub fn copy_dir<T: AsRef<Path>, U: AsRef<Path>>(src: T, dst: U) -> anyhow_ext::R
     for p in jwalk::WalkDir::new(&src) {
         let from = p?.path();
         let to = dst.as_ref().join(from.strip_prefix(&src)?);
-        if from.is_dir() {
+        if from.is_dir() && !to.exists() {
             std::fs::create_dir(to)?;
         } else if from.is_file() {
             std::fs::copy(from, to)?;

--- a/crates/uk-manager/src/util.rs
+++ b/crates/uk-manager/src/util.rs
@@ -8,6 +8,19 @@ use anyhow_ext::Context;
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
 pub use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+pub fn copy_dir<T: AsRef<Path>, U: AsRef<Path>>(src: T, dst: U) -> anyhow_ext::Result<()> {
+    for p in jwalk::WalkDir::new(&src) {
+        let from = p?.path();
+        let to = dst.as_ref().join(from.strip_prefix(&src)?);
+        if from.is_dir() {
+            std::fs::create_dir(to)?;
+        } else if from.is_file() {
+            std::fs::copy(from, to)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn remove_dir_all(dir: impl AsRef<std::path::Path>) -> anyhow_ext::Result<()> {
     fn inner(dir: &Path) -> anyhow_ext::Result<()> {
         #[cfg(windows)]

--- a/src/gui/tasks.rs
+++ b/src/gui/tasks.rs
@@ -34,6 +34,15 @@ mod handlers;
 pub use handlers::register_handlers;
 
 fn is_probably_a_mod_and_has_meta(path: &Path) -> (bool, bool) {
+    if path
+        .file_name()
+        .unwrap_or_default()
+        .to_str()
+        .unwrap_or_default()
+        == "rules.txt"
+    {
+        return (true, true);
+    }
     let ext = path
         .extension()
         .and_then(|e| e.to_str().map(|e| e.to_lowercase()))
@@ -42,14 +51,6 @@ fn is_probably_a_mod_and_has_meta(path: &Path) -> (bool, bool) {
         (false, false)
     } else if ext == "7z" {
         (true, false)
-    } else if path
-        .file_name()
-        .unwrap_or_default()
-        .to_str()
-        .unwrap_or_default()
-        == "rules.txt"
-    {
-        (true, true)
     } else {
         match fs::File::open(path)
             .context("")
@@ -104,7 +105,7 @@ pub fn open_mod(core: &Manager, path: &Path, meta: Option<Meta>) -> Result<Messa
             .filter(|(is_mod, _has_meta)| *is_mod)
             .map(|(_, has_meta)| has_meta)
             {
-                log::info!("Maybe it's not a UKMM mod, let's to convert it");
+                log::info!("Maybe it's not a UKMM mod, let's try to convert it");
                 if !has_meta && meta.is_none() {
                     log::info!("Mod has no meta info, requesting manual input");
                     return Ok(Message::RequestMeta(path.to_path_buf()));

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -230,10 +230,10 @@ impl App {
                 Message::SelectFile => {
                     if let Some(mut paths) = rfd::FileDialog::new()
                         .set_title("Select a Mod")
-                        .add_filter("Any mod (*.zip, *.7z, *.bnp)", &["zip", "bnp", "7z"])
+                        .add_filter("Any mod (*.zip, *.7z, *.bnp, rules.txt)", &["zip", "bnp", "7z", "txt"])
                         .add_filter("UKMM Mod (*.zip)", &["zip"])
                         .add_filter("BCML Mod (*.bnp)", &["bnp"])
-                        .add_filter("Legacy Mod (*.zip, *.7z)", &["zip", "7z"])
+                        .add_filter("Legacy Mod (*.zip, *.7z, rules.txt)", &["zip", "7z", "txt"])
                         .add_filter("All files (*.*)", &["*"])
                         .pick_files()
                         .filter(|p| !p.is_empty())

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -193,7 +193,7 @@ impl App {
                 Message::DuplicateProfile(profile) => {
                     self.do_task(move |core| {
                         let profiles_dir = core.settings().profiles_dir();
-                        dircpy::copy_dir(
+                        uk_manager::util::copy_dir(
                             profiles_dir.join(&profile),
                             profiles_dir.join(profile + "_copy"),
                         )?;


### PR DESCRIPTION
Fixes the issue where, on Windows, dircpy's method of file copying happens too slow and the task dispatch kills the thread before the file copy finishes. (At least, that's my best guess for what's happening) Rather than shelling out the copy calls, it runs a synchronous operation.

Also fixes an issue where mods could not be installed by rules.txt because anything without a `zip` or `7z` extension got eaten by previous if cases. I'm rolling this into the same PR because I accidentally rolled them into the same commit, and had previously kept the bug around specifically as a workaround for the file copying issue.

Doesn't add `*.txt` to the installation selection dialogue. Need to find time to figure out how to do that, but wanted to get this up because I rolled it into my side-0.15.0 and didn't want 0.15.1 to regress if you found time to do a release before I could find it.

Addresses, closes #207 