### PR TITLE
Pending log hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to UKMM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0-1] 2026-04-10
+
+This release is a hotfix for 0.17.0, which fixes conversions from the old pending
+deployment log format to the new one.
+
+**Fixed**
+
+- Fixed a crash on program bootup, related to path traversal when converting
+  old pending logs to new ones when the old logs contain an empty path
+
 ## [0.17.0] - 2026-04-09
 
 This release includes multiple *breaking changes* to the UKMM mod format. This means

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "uk-content"
-version = "0.17.0"
+version = "0.17.0-1"
 dependencies = [
  "almost",
  "anyhow",
@@ -5667,7 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "uk-localization"
-version = "0.17.0"
+version = "0.17.0-1"
 dependencies = [
  "dashmap",
  "parking_lot",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "uk-manager"
-version = "0.17.0"
+version = "0.17.0-1"
 dependencies = [
  "anyhow",
  "anyhow_ext",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "uk-mod"
-version = "0.17.0"
+version = "0.17.0-1"
 dependencies = [
  "anyhow",
  "anyhow_ext",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "uk-reader"
-version = "0.17.0"
+version = "0.17.0-1"
 dependencies = [
  "anyhow",
  "anyhow_ext",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "uk-ui"
-version = "0.17.0"
+version = "0.17.0-1"
 dependencies = [
  "catppuccin-egui",
  "color-hex",
@@ -5804,11 +5804,11 @@ dependencies = [
 
 [[package]]
 name = "uk-util"
-version = "0.17.0"
+version = "0.17.0-1"
 
 [[package]]
 name = "ukmm"
-version = "0.17.0"
+version = "0.17.0-1"
 dependencies = [
  "anyhow",
  "anyhow_ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.0-1"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/crates/uk-manager/src/deploy.rs
+++ b/crates/uk-manager/src/deploy.rs
@@ -90,7 +90,11 @@ impl Manager {
                                 Default::default()
                             }
                         };
-                        old_pending.try_into()?
+                        old_pending.try_into().unwrap_or_else(|e| {
+                            log::warn!("Could not load pending deployment data:\n{}", &e);
+                            log::info!("No files pending deployment");
+                            Default::default()
+                        })
                     }
                 }
             }

--- a/crates/uk-manager/src/deploy/pending_log.rs
+++ b/crates/uk-manager/src/deploy/pending_log.rs
@@ -22,6 +22,7 @@ impl TryFrom<crate::deploy::OldPendingLog> for PendingLog {
             let mut map: Folder = Default::default();
             for f in files {
                 let path = PathBuf::from(f.as_str());
+                if path.to_string_lossy().is_empty() { continue; }
                 let mut iter = path.iter();
                 let name: String = iter.next()
                     .ok_or(anyhow!("{} is empty?", f))?


### PR DESCRIPTION
Fixes a crash on program bootup, related to path traversal when converting old pending logs to new ones when the old logs contain an empty path