### PR TITLE
Error context clarity

### DIFF
--- a/crates/uk-content/src/actor/params/as/ext_float_array.rs
+++ b/crates/uk-content/src/actor/params/as/ext_float_array.rs
@@ -20,10 +20,11 @@ impl TryFrom<&ParameterList> for FloatArray {
                 .ok_or(UKError::MissingAampKey("FloatArray missing FloatArray0", Box::from(None)))?
                 .iter()
                 .map(|(n, v)| -> Result<(i32, f32)> {
+                    let index = super::get_value_index(n.hash())
+                        .context(format!("Could not get index of Value with key hash {}", n))?;
                     Ok((
-                        super::get_value_index(n.hash())
-                            .context(format!("FloatArray has invalid key: {}", n))?,
-                        v.as_f32().context("FloatArray contains non-float")?
+                        index,
+                        v.as_f32().context(format!("FloatArray has invalid Value{}", index))?
                     ))
                 })
                 .collect::<Result<_>>()?,

--- a/crates/uk-content/src/actor/params/as/ext_int_array.rs
+++ b/crates/uk-content/src/actor/params/as/ext_int_array.rs
@@ -20,10 +20,11 @@ impl TryFrom<&ParameterList> for IntArray {
                 .ok_or(UKError::MissingAampKey("IntArray missing IntArray0", Box::from(None)))?
                 .iter()
                 .map(|(n, v)| -> Result<(i32, i32)> {
+                    let index = super::get_value_index(n.hash())
+                        .context(format!("Could not get index of Value with key hash {}", n))?;
                     Ok((
-                        super::get_value_index(n.hash())
-                            .context(format!("IntArray has invalid key: {}", n))?,
-                        v.as_i32().context("IntArray contains non-integer")?
+                        index,
+                        v.as_i32().context(format!("IntArray has invalid Value{}", index))?
                     ))
                 })
                 .collect::<Result<_>>()?,

--- a/crates/uk-content/src/actor/params/as/ext_string_array.rs
+++ b/crates/uk-content/src/actor/params/as/ext_string_array.rs
@@ -21,9 +21,13 @@ impl TryFrom<&ParameterList> for StringArray {
                 .ok_or(UKError::MissingAampKey("StringArray missing StringArray0", Box::from(None)))?
                 .iter()
                 .map(|(n, v)| -> Result<(i32, String)> {
+                    let index = super::get_value_index(n.hash())
+                        .context(format!("Could not get index of Value with key hash {}", n))?;
                     Ok((
-                        super::get_value_index(n.hash())?,
-                        v.as_str().context("StringArray contains non-string")?.into()
+                        index,
+                        v.as_str()
+                            .context(format!("StringArray has invalid Value{}", index))?
+                            .into()
                     ))
                 })
                 .collect::<Result<_>>()?,

--- a/crates/uk-content/src/actor/params/as/mod.rs
+++ b/crates/uk-content/src/actor/params/as/mod.rs
@@ -140,9 +140,7 @@ impl TryFrom<&ParameterList> for Element {
             ResType::WeightBlender |
             ResType::WindVelocityBlender |
             ResType::YSpeedBlender |
-            ResType::ZEx00ExposureBlender => Ok(Element::Blender(
-                value.try_into().context("Bas file has invalid Blender")?
-            )),
+            ResType::ZEx00ExposureBlender => Ok(Element::Blender(value.try_into()?)),
             ResType::AbsTemperatureSelector |
             ResType::ArmorSelector |
             ResType::ArrowSelector |
@@ -208,30 +206,18 @@ impl TryFrom<&ParameterList> for Element {
             ResType::WeatherSelector |
             ResType::WeightSelector |
             ResType::YSpeedSelector |
-            ResType::ZEx00ExposureSelector => Ok(Element::Selector(
-                value.try_into().context("Bas file has invalid Selector")?
-            )),
+            ResType::ZEx00ExposureSelector => Ok(Element::Selector(value.try_into()?)),
             ResType::BoneVisibilityAsset |
             ResType::MatVisibilityAsset |
             ResType::ShaderParamAsset |
             ResType::ShaderParamColorAsset |
             ResType::ShaderParamTexSRTAsset |
-            ResType::TexturePatternAsset => Ok(Element::AssetEx(
-                value.try_into().context("Bas file has invalid AssetEx")?
-            )),
+            ResType::TexturePatternAsset => Ok(Element::AssetEx(value.try_into()?)),
             ResType::ClearMatAnmAsset |
-            ResType::NoAnmAsset => Ok(Element::Resource(
-                value.try_into().context("Bas file has invalid Resource")?
-            )),
-            ResType::SequencePlayContainer => Ok(Element::SequencePlayContainer(
-                value.try_into().context("Bas file has invalid SequencePlayContainer")?
-            )),
-            ResType::SkeletalAsset => Ok(Element::SkeletalAsset(
-                value.try_into().context("Bas file has invalid SkeletalAsset")?
-            )),
-            ResType::SyncPlayContainer => Ok(Element::ResourceWithChildren(
-                value.try_into().context("Bas file has invalid ResourceWithChildren")?
-            )),
+            ResType::NoAnmAsset => Ok(Element::Resource(value.try_into()?)),
+            ResType::SequencePlayContainer => Ok(Element::SequencePlayContainer(value.try_into()?)),
+            ResType::SkeletalAsset => Ok(Element::SkeletalAsset(value.try_into()?)),
+            ResType::SyncPlayContainer => Ok(Element::ResourceWithChildren(value.try_into()?)),
             ResType::Invalid => Err(UKError::Any(anyhow!(
                 "Bas file has invalid Element (TypeIndex: {})",
                 type_index

--- a/crates/uk-content/src/actor/params/as/res.rs
+++ b/crates/uk-content/src/actor/params/as/res.rs
@@ -35,7 +35,7 @@ impl TryFrom<&ParameterList> for Resource {
                     .collect::<Result<_>>()
                 )
                 .transpose()
-                .context("Resource has invalid Extend")?,
+                .context("Element has invalid Extend")?,
         })
     }
 }
@@ -46,7 +46,7 @@ impl From<Resource> for ParameterList {
             objects: objs!(
                 "Parameters" => params!(
                     "TypeIndex" => value.type_index
-                        .expect("Resource TypeIndex should have been read on import")
+                        .expect("Element TypeIndex should have been read on import")
                         .into(),
                 )
             ),

--- a/crates/uk-content/src/actor/params/as/res.rs
+++ b/crates/uk-content/src/actor/params/as/res.rs
@@ -46,7 +46,7 @@ impl From<Resource> for ParameterList {
             objects: objs!(
                 "Parameters" => params!(
                     "TypeIndex" => value.type_index
-                        .expect("Element TypeIndex should have been read on import")
+                        .expect("Resource TypeIndex should have been read on import")
                         .into(),
                 )
             ),

--- a/crates/uk-content/src/actor/params/as/res_asset.rs
+++ b/crates/uk-content/src/actor/params/as/res_asset.rs
@@ -20,11 +20,11 @@ impl TryFrom<&ParameterList> for AssetResource {
             base: Some(value.try_into()?),
             file_name: Some(value.objects
                 .get("Parameters")
-                .ok_or(UKError::MissingAampKey("AssetResource missing Parameters", Box::from(None)))?
+                .ok_or(UKError::MissingAampKey("Element missing Parameters", Box::from(None)))?
                 .get("FileName")
-                .ok_or(UKError::MissingAampKey("AssetResource missing FileName", Box::from(None)))?
+                .ok_or(UKError::MissingAampKey("Element missing FileName", Box::from(None)))?
                 .as_str()
-                .context("AssetResource has invalid FileName")?
+                .context("Element has invalid FileName")?
                 .into()),
         })
     }

--- a/crates/uk-content/src/actor/params/as/res_asset.rs
+++ b/crates/uk-content/src/actor/params/as/res_asset.rs
@@ -17,7 +17,7 @@ impl TryFrom<&ParameterList> for AssetResource {
 
     fn try_from(value: &ParameterList) -> Result<Self> {
         Ok(Self {
-            base: Some(value.try_into().context("AssetResource has invalid Resource")?),
+            base: Some(value.try_into()?),
             file_name: Some(value.objects
                 .get("Parameters")
                 .ok_or(UKError::MissingAampKey("AssetResource missing Parameters", Box::from(None)))?

--- a/crates/uk-content/src/actor/params/as/res_asset_ex.rs
+++ b/crates/uk-content/src/actor/params/as/res_asset_ex.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use roead::aamp::ParameterList;
 use serde::{Deserialize, Serialize};
 use crate::prelude::Mergeable;
@@ -15,7 +14,7 @@ impl TryFrom<&ParameterList> for AssetExResource {
 
     fn try_from(value: &ParameterList) -> Result<Self> {
         Ok(Self {
-            base: Some(value.try_into().context("AssetExResource has invalid AssetResource")?),
+            base: Some(value.try_into()?),
         })
     }
 }

--- a/crates/uk-content/src/actor/params/as/res_blender.rs
+++ b/crates/uk-content/src/actor/params/as/res_blender.rs
@@ -19,20 +19,20 @@ impl TryFrom<&ParameterList> for BlenderResource {
     fn try_from(value: &ParameterList) -> Result<Self> {
         let parameters = value.objects
             .get("Parameters")
-            .ok_or(UKError::MissingAampKey("BlenderResource missing Parameters", Box::from(None)))?;
+            .ok_or(UKError::MissingAampKey("Element missing Parameters", Box::from(None)))?;
         Ok(Self {
             base: Some(value.try_into()?),
             no_sync: parameters
                 .get("NoSync")
-                .map(|p| p.as_bool().context("BlenderResource has invalid NoSync"))
+                .map(|p| p.as_bool().context("Element has invalid NoSync"))
                 .transpose()?,
             judge_once: parameters
                 .get("JudgeOnce")
-                .map(|p| p.as_bool().context("BlenderResource has invalid JudgeOnce"))
+                .map(|p| p.as_bool().context("Element has invalid JudgeOnce"))
                 .transpose()?,
             input_limit: parameters
                 .get("InputLimit")
-                .map(|p| p.as_f32().context("BlenderResource has invalid InputLimit"))
+                .map(|p| p.as_f32().context("Element has invalid InputLimit"))
                 .transpose()?,
         })
     }

--- a/crates/uk-content/src/actor/params/as/res_blender.rs
+++ b/crates/uk-content/src/actor/params/as/res_blender.rs
@@ -21,7 +21,7 @@ impl TryFrom<&ParameterList> for BlenderResource {
             .get("Parameters")
             .ok_or(UKError::MissingAampKey("BlenderResource missing Parameters", Box::from(None)))?;
         Ok(Self {
-            base: Some(value.try_into().context("BlenderResource has invalid ResourceWithChildren")?),
+            base: Some(value.try_into()?),
             no_sync: parameters
                 .get("NoSync")
                 .map(|p| p.as_bool().context("BlenderResource has invalid NoSync"))

--- a/crates/uk-content/src/actor/params/as/res_children.rs
+++ b/crates/uk-content/src/actor/params/as/res_children.rs
@@ -19,15 +19,17 @@ impl TryFrom<&ParameterList> for ResourceWithChildren {
     fn try_from(value: &ParameterList) -> Result<Self> {
         let children = value.objects
             .get("Children")
-            .ok_or(UKError::MissingAampKey("ResourceWithChildren missing Children", Box::from(None)))?;
+            .ok_or(UKError::MissingAampKey("Element missing Children", Box::from(None)))?;
         Ok(Self {
             base: Some(value.try_into()?),
             children: children
                 .iter()
                 .map(|(n, p)| -> Result<(i32, i32)> {
+                    let index = get_child_index(n.hash())
+                        .context(format!("Could not get index of Child with key hash {}", n))?;
                     Ok((
-                        get_child_index(n.hash())?,
-                        p.as_i32().context("ResourceWithChildren has invalid Child Index")?
+                        index,
+                        p.as_i32().context(format!("Element has invalid Child{}", index))?
                     ))
                 })
                 .collect::<Result<_>>()?,

--- a/crates/uk-content/src/actor/params/as/res_children.rs
+++ b/crates/uk-content/src/actor/params/as/res_children.rs
@@ -21,7 +21,7 @@ impl TryFrom<&ParameterList> for ResourceWithChildren {
             .get("Children")
             .ok_or(UKError::MissingAampKey("ResourceWithChildren missing Children", Box::from(None)))?;
         Ok(Self {
-            base: Some(value.try_into().context("ResourceWithChildren has invalid Resource")?),
+            base: Some(value.try_into()?),
             children: children
                 .iter()
                 .map(|(n, p)| -> Result<(i32, i32)> {

--- a/crates/uk-content/src/actor/params/as/res_selector.rs
+++ b/crates/uk-content/src/actor/params/as/res_selector.rs
@@ -20,7 +20,7 @@ impl TryFrom<&ParameterList> for SelectorResource {
             .get("Parameters")
             .ok_or(UKError::MissingAampKey("SelectorResource missing Parameters", Box::from(None)))?;
         Ok(Self {
-            base: Some(value.try_into().context("SelectorResource has invalid ResourceWithChildren")?),
+            base: Some(value.try_into()?),
             no_sync: parameters
                 .get("NoSync")
                 .map(|p| p.as_bool().context("SelectorResource has invalid NoSync"))

--- a/crates/uk-content/src/actor/params/as/res_selector.rs
+++ b/crates/uk-content/src/actor/params/as/res_selector.rs
@@ -18,16 +18,16 @@ impl TryFrom<&ParameterList> for SelectorResource {
     fn try_from(value: &ParameterList) -> Result<Self> {
         let parameters = value.objects
             .get("Parameters")
-            .ok_or(UKError::MissingAampKey("SelectorResource missing Parameters", Box::from(None)))?;
+            .ok_or(UKError::MissingAampKey("Element missing Parameters", Box::from(None)))?;
         Ok(Self {
             base: Some(value.try_into()?),
             no_sync: parameters
                 .get("NoSync")
-                .map(|p| p.as_bool().context("SelectorResource has invalid NoSync"))
+                .map(|p| p.as_bool().context("Element has invalid NoSync"))
                 .transpose()?,
             judge_once: parameters
                 .get("JudgeOnce")
-                .map(|p| p.as_bool().context("SelectorResource has invalid JudgeOnce"))
+                .map(|p| p.as_bool().context("Element has invalid JudgeOnce"))
                 .transpose()?,
         })
     }

--- a/crates/uk-content/src/actor/params/as/res_seq_play.rs
+++ b/crates/uk-content/src/actor/params/as/res_seq_play.rs
@@ -16,7 +16,7 @@ impl TryFrom<&ParameterList> for SequencePlayContainerResource {
 
     fn try_from(value: &ParameterList) -> Result<Self> {
         Ok(Self {
-            base: Some(value.try_into().context("SequencePlayContainerResource has invalid ResourceWithChildren")?),
+            base: Some(value.try_into()?),
             sequence_loop: Some(value.objects
                 .get("Parameters")
                 .ok_or(UKError::MissingAampKey(

--- a/crates/uk-content/src/actor/params/as/res_seq_play.rs
+++ b/crates/uk-content/src/actor/params/as/res_seq_play.rs
@@ -19,17 +19,11 @@ impl TryFrom<&ParameterList> for SequencePlayContainerResource {
             base: Some(value.try_into()?),
             sequence_loop: Some(value.objects
                 .get("Parameters")
-                .ok_or(UKError::MissingAampKey(
-                    "SequencePlayContainerResource missing Parameters",
-                    Box::from(None)
-                ))?
+                .ok_or(UKError::MissingAampKey("Element missing Parameters", Box::from(None)))?
                 .get("SequenceLoop")
-                .ok_or(UKError::MissingAampKey(
-                    "SequencePlayContainerResource missing SequenceLoop",
-                    Box::from(None)
-                ))?
+                .ok_or(UKError::MissingAampKey("Element missing SequenceLoop", Box::from(None)))?
                 .as_bool()
-                .context("SequencePlayContainerResource has invalid SequenceLoop")?),
+                .context("Element has invalid SequenceLoop")?),
         })
     }
 }

--- a/crates/uk-content/src/actor/params/as/res_skel_asset.rs
+++ b/crates/uk-content/src/actor/params/as/res_skel_asset.rs
@@ -24,7 +24,7 @@ impl TryFrom<&ParameterList> for SkeletalAssetResource {
                 Box::from(None)
             ))?;
         Ok(Self {
-            base: Some(value.try_into().context("SkeletalAssetResource has invalid AssetResource")?),
+            base: Some(value.try_into()?),
             init_anm_driven: parameters
                 .get("InitAnmDriven")
                 .map(|p| p.as_i32().context("SkeletalAssetResource has invalid InitAnmDriven"))

--- a/crates/uk-content/src/actor/params/as/res_skel_asset.rs
+++ b/crates/uk-content/src/actor/params/as/res_skel_asset.rs
@@ -19,23 +19,20 @@ impl TryFrom<&ParameterList> for SkeletalAssetResource {
     fn try_from(value: &ParameterList) -> Result<Self> {
         let parameters = value.objects
             .get("Parameters")
-            .ok_or(UKError::MissingAampKey(
-                "SkeletalAssetResource missing Parameters",
-                Box::from(None)
-            ))?;
+            .ok_or(UKError::MissingAampKey("Element missing Parameters", Box::from(None)))?;
         Ok(Self {
             base: Some(value.try_into()?),
             init_anm_driven: parameters
                 .get("InitAnmDriven")
-                .map(|p| p.as_i32().context("SkeletalAssetResource has invalid InitAnmDriven"))
+                .map(|p| p.as_i32().context("Element has invalid InitAnmDriven"))
                 .transpose()?,
             morph: parameters
                 .get("Morph")
-                .map(|p| p.as_f32().context("SkeletalAssetResource has invalid Morph"))
+                .map(|p| p.as_f32().context("Element has invalid Morph"))
                 .transpose()?,
             reset_morph: parameters
                 .get("ResetMorph")
-                .map(|p| p.as_f32().context("SkeletalAssetResource has invalid ResetMorph"))
+                .map(|p| p.as_f32().context("Element has invalid ResetMorph"))
                 .transpose()?,
         })
     }


### PR DESCRIPTION
Makes error contexts more closely resemble for the format of the bas file, so an author (or knowledgeable user) seeing the error contexts won't need to parse out internal ukmm structuring to see where their error actually is.