### PR TITLE
Get rid of several fallible bare unwrap()s

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,11 +53,6 @@ jobs:
     - name: Install NASM (Windows)
       if: matrix.platform == 'windows-latest'
       uses: ilammy/setup-nasm@v1
-    - name: Setup cmake (Windows)
-      if: matrix.platform == 'windows-latest'
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.31.x'
     - name: Install latest nightly
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,11 @@ jobs:
     - name: Install NASM (Windows)
       if: matrix.platform == 'windows-latest'
       uses: ilammy/setup-nasm@v1
+    - name: Setup cmake (Windows)
+      if: matrix.platform == 'windows-latest'
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.31.x'
     - name: Install latest nightly
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4575,7 +4575,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 [[package]]
 name = "rstb"
 version = "1.0.0"
-source = "git+https://github.com/GingerAvalanche/rstb-rust.git?branch=chemical#65599d9edf11bdc5c4820dbde2422e52eefd49e0"
+source = "git+https://github.com/GingerAvalanche/rstb-rust.git?branch=chemical#886d543bc4e81a8d5bd7b8f074d2f0d117368e55"
 dependencies = [
  "crc",
  "include-flate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,27 +529,24 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea835662a0af02443aa1396d39be523bbf8f11ee6fad20329607c480bea48c3"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.25.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "paste",
 ]
 
 [[package]]
@@ -580,29 +577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.8.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.96",
- "which 4.4.2",
 ]
 
 [[package]]
@@ -908,13 +882,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -922,15 +897,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-expr"
@@ -991,17 +957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1723,7 +1678,6 @@ checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
 dependencies = [
  "ahash",
  "egui",
- "ehttp",
  "enum-map",
  "image",
  "log",
@@ -1757,20 +1711,6 @@ dependencies = [
  "egui",
  "log",
  "regex",
-]
-
-[[package]]
-name = "ehttp"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a81c221a1e4dad06cb9c9deb19aea1193a5eea084e8cd42d869068132bf876"
-dependencies = [
- "document-features",
- "js-sys",
- "ureq",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -2037,6 +1977,12 @@ dependencies = [
  "filetime",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -2486,12 +2432,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92208b0986f414edaca8ede2c6962c979309346a9e8e19d07d0a7879aae1549e"
 dependencies = [
- "rustls",
- "rustls-pemfile",
- "rustls-pki-types",
+ "native-tls",
  "unicase",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2930,12 +2872,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lebe"
@@ -3450,6 +3386,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3802,6 +3755,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if 1.0.0",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4064,16 +4060,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
-dependencies = [
- "proc-macro2 1.0.93",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -4622,14 +4608,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4637,25 +4622,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-pki-types"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "rustls-pki-types",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
-
-[[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4713,6 +4692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4735,6 +4723,29 @@ name = "sdd"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -4923,6 +4934,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5839,7 +5856,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "sevenz-rust",
- "shlex",
+ "shlex 1.3.0",
  "smartstring",
  "ssilide",
  "strfmt",
@@ -5851,7 +5868,7 @@ dependencies = [
  "uk-ui",
  "uk-util",
  "unrar",
- "which 6.0.3",
+ "which",
  "winreg",
  "winres",
  "xflags",
@@ -5922,22 +5939,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots",
-]
 
 [[package]]
 name = "url"
@@ -6044,6 +6045,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -6323,41 +6330,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "which"
@@ -6485,6 +6461,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6537,6 +6519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,17 +45,15 @@ unrar = { workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate"] }
 
 astrolabe = "0.5.1"
-egui_commonmark = { version = "0.17.0", features = ["svg", "fetch"] }
+egui_commonmark = { version = "0.17.0", features = ["svg"] }
 egui-notify = "0.15.0"
 egui_logger = "0.5"
-http_req = { version = "^0.12", default-features = false, features = [
-    "rust-tls",
-] }
+http_req = { version = "^0.12", default-features = false, features = ["native-tls"] }
 image = { version = "0.25.1", features = ["jpeg", "png"] }
 mimalloc = { version = "0.1.43", default-features = false }
 open = "5.2"
 roxmltree = "0.20.0"
-rustls = "0.23.12"
+rustls = "0.23.40"
 shlex = "1.3.0"
 uk-content = { path = "crates/uk-content" }
 uk-localization = { path = "crates/uk-localization" }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Requirements:
 
 - Recent Rust toolchain (MSRV 1.80)
 - A compiler that supports C++17
-- CMake (3.12+ and <4.0)
+- Modern CMake (4+)
 
 Nothing else special is required. Generate a release build by running `cargo
 build --release` in the root repo folder. It may take a while.

--- a/crates/uk-content/src/actor/params/aiprog.rs
+++ b/crates/uk-content/src/actor/params/aiprog.rs
@@ -499,7 +499,6 @@ impl Writer {
         }
     }
 
-    #[allow(clippy::unwrap_used)]
     fn entry_to_list(&mut self, entry: AIEntry) -> usize {
         if let Some(index) = self
             .finished
@@ -555,9 +554,9 @@ impl Writer {
                         *self
                             .ais
                             .get_mut(&name)
-                            .unwrap()
+                            .unwrap_or_else(|| panic!("Err line 557: {}", &name))
                             .object_mut("ChildIdx")
-                            .unwrap() = children;
+                            .unwrap_or_else(|| panic!("Err line 559: ChildIdx inside {}", &name)) = children;
                     }
                     self.finished.insert(def, index);
                     index
@@ -575,9 +574,9 @@ impl Writer {
                         *self
                             .ais
                             .get_mut(&name)
-                            .unwrap()
+                            .unwrap_or_else(|| panic!("Err line 577: {}", &name))
                             .object_mut("ChildIdx")
-                            .unwrap() = children;
+                            .unwrap_or_else(|| panic!("Err line 579: ChildIdx inside {}", &name)) = children;
                     }
                     self.finished.insert(def, index);
                     index

--- a/crates/uk-content/src/font/mod.rs
+++ b/crates/uk-content/src/font/mod.rs
@@ -35,7 +35,6 @@ impl Mergeable for FontArchive {
         )
     }
 
-    #[allow(clippy::unwrap_used)]
     fn merge(&self, diff: &Self) -> Self {
         let keys: HashSet<String> = self.0.keys().chain(diff.0.keys()).cloned().collect();
         Self(
@@ -46,7 +45,7 @@ impl Mergeable for FontArchive {
                         .get(&k)
                         .or_else(|| self.0.get(&k))
                         .map(|v| v.to_vec())
-                        .unwrap();
+                        .expect("Font archive merging failed");
                     (k, v)
                 })
                 .collect(),

--- a/crates/uk-content/src/layout/mod.rs
+++ b/crates/uk-content/src/layout/mod.rs
@@ -35,7 +35,6 @@ impl Mergeable for LayoutArchive {
         )
     }
 
-    #[allow(clippy::unwrap_used)]
     fn merge(&self, diff: &Self) -> Self {
         let keys: HashSet<String> = self.0.keys().chain(diff.0.keys()).cloned().collect();
         Self(
@@ -46,7 +45,7 @@ impl Mergeable for LayoutArchive {
                         .get(&k)
                         .or_else(|| self.0.get(&k))
                         .map(|v| v.to_vec())
-                        .unwrap();
+                        .expect("Layout archive merging failed");
                     (k, v)
                 })
                 .collect(),

--- a/crates/uk-manager/src/deploy.rs
+++ b/crates/uk-manager/src/deploy.rs
@@ -232,8 +232,8 @@ impl Manager {
                     .context("Failed to remove symlink to old symlinked dlc")?;
             }
             else if settings.current_mode == Platform::WiiU &&
-                util::is_symlink(&dest_aoc.parent().unwrap()) {
-                util::remove_symlink(&dest_aoc.parent().unwrap())
+                util::is_symlink(dest_aoc.parent().unwrap()) {
+                util::remove_symlink(dest_aoc.parent().unwrap())
                     .context("Failed to remove symlink to old symlinked dlc")?;
             }
             if !dest_content.exists() {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -425,7 +425,7 @@ impl App {
                                     .to_string(),
                             )
                         })
-                    ))
+                    ).context(std::backtrace::Backtrace::force_capture()))
                 }
             };
             if let Some(d) = core.settings().dump() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,9 @@ fn main() -> Result<()> {
                     }
                 }
                 gui::tasks::wait_ipc();
+                std::panic::set_hook(Box::new(|_| {
+                    println!("{}", std::backtrace::Backtrace::force_capture());
+                }));
                 if let Err(e) = std::panic::catch_unwind(gui::main) {
                     display_error(e);
                     if let Some(file) = logger::LOGGER.log_path() {


### PR DESCRIPTION
This also includes (theoretically) an update to the build target for rstb-rust, which should include more unwrap_or_else replacements