### PR TITLE
Handle BNP conversion when DLC is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.1] 2026-07-01
 
+**Added**
+
+- Added experimental support for converting map-mod bnps when dlc is not installed
+
 **Changed**
 
 - Cleaned up Cemu importer code a bit. Should be slightly faster and less prone

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,9 +4401,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.8.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a694f9e0eb3104451127f6cc1e5de55f59d3b1fc8c5ddfaeb6f1e716479ceb4a"
+checksum = "808cc0b475acf76adf36f08ca49429b12aad9f678cb56143d5b3cb49b9a1dd08"
 dependencies = [
  "cfg-if 1.0.0",
  "cvt",
@@ -5102,12 +5102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "split-iter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2b15926089e5526bb2dd738a2eb0e59034356e06eb71e1cd912358c0e62c4d"
-
-[[package]]
 name = "ssilide"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5721,7 +5715,6 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "sevenz-rust",
  "smartstring",
- "split-iter",
  "tempfile",
  "uk-content",
  "uk-localization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ xflags = "0.3.1"
 astrolabe = "0.5.2"
 
 [target.'cfg(windows)'.dependencies]
-remove_dir_all = "0.8"
+remove_dir_all = "1.0.0"
 winreg = "0.52.0"
 
 [target.'cfg(windows)'.build-dependencies]

--- a/crates/uk-manager/Cargo.toml
+++ b/crates/uk-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uk-manager"
 authors = ["Caleb Smith <c.smith@tuta.io>"]
-edition = "2021"
+edition = "2024"
 version.workspace = true
 
 [dependencies]
@@ -31,7 +31,6 @@ smartstring = { workspace = true, features = ["serde"] }
 unrar = { workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate"] }
 
-split-iter = "0.1.0"
 tempfile = "3.3"
 uk-content = { path = "../uk-content" }
 uk-localization = { path = "../uk-localization" }
@@ -41,4 +40,4 @@ uk-util = { path = "../uk-util" }
 
 [target.'cfg(windows)'.dependencies]
 junction = { git = "https://github.com/NiceneNerd/junction" }
-remove_dir_all = "0.8.1"
+remove_dir_all = "1.0.0"

--- a/crates/uk-manager/src/bnp.rs
+++ b/crates/uk-manager/src/bnp.rs
@@ -107,6 +107,8 @@ struct BnpConverter {
     packs: Arc<DashSet<PathBuf>>,
     parent_packs: DashSet<PathBuf>,
     opt_master_cache: Arc<DashMap<PathBuf, Vec<u8>>>,
+    root_maps: Arc<DashMap<String, Vec<u8>>>,
+    opt_maps: Arc<DashMap<String, Vec<u8>>>,
 }
 
 impl BnpConverter {
@@ -529,6 +531,8 @@ pub fn unpack_bnp(core: &crate::core::Manager, path: &Path) -> Result<PathBuf> {
         current_root: tempdir.clone(),
         path: tempdir.clone(),
         opt_master_cache: Default::default(),
+        root_maps: Default::default(),
+        opt_maps: Default::default(),
     };
     let path = converter.convert()?;
     log::info!("BNP unpacked");

--- a/crates/uk-manager/src/bnp.rs
+++ b/crates/uk-manager/src/bnp.rs
@@ -47,7 +47,7 @@ pub enum AampDiffEntry {
 
 impl AampDiffEntry {
     pub fn as_mut_sarc(&mut self) -> &mut AampDiffMap {
-        if let AampDiffEntry::Sarc(ref mut map) = self {
+        if let AampDiffEntry::Sarc(map) = self {
             map
         } else {
             panic!("Not a SARC entry")
@@ -457,6 +457,7 @@ impl BnpConverter {
 
     fn convert(mut self) -> Result<PathBuf> {
         let root = self.current_root.clone();
+        self.set_up_temp_map_state().context("Failed to set up temp map state for root")?;
         self.convert_root()?;
 
         let opt_dir = root.join("options");
@@ -475,10 +476,22 @@ impl BnpConverter {
                         .unwrap_or_default()
                 );
                 self.current_root = option;
+                self.set_up_temp_map_state()
+                    .with_context(|| format!(
+                        "Failed to set up temp map state for {}",
+                        self.current_root.display()
+                    ))?;
                 self.convert_root()?;
+                self.clear_temp_map_state()
+                    .with_context(|| format!(
+                        "Failed to clear temp map state for {}",
+                        self.current_root.display()
+                    ))?;
             }
         }
-        Ok(root)
+        self.current_root = root;
+        self.clear_temp_map_state().context("Failed to clear temp map state for root")?;
+        Ok(self.current_root)
     }
 }
 

--- a/crates/uk-manager/src/bnp/maps.rs
+++ b/crates/uk-manager/src/bnp/maps.rs
@@ -9,7 +9,6 @@ use roead::{
     yaz0::{compress, decompress},
 };
 use rustc_hash::FxHashMap;
-use crate::util;
 use super::BnpConverter;
 
 fn merge_map(base: &mut Byml, diff: Byml) -> Result<()> {
@@ -82,19 +81,12 @@ impl BnpConverter {
         let maps_path = self.current_root.join("logs/map.yml");
         if !maps_path.exists() { return Ok(()) }
 
-        let canon_rel = Path::new("Map/MainField");
-        let map_tmp = self.current_root.join("map_tmp");
-        std::fs::create_dir_all(map_tmp.join(canon_rel))
-            .context("Failed to create temp MainField dir")?;
-        for x in 'A'..'K' {
-            for y in 1..9 {
-                let current_dir = canon_rel.join(format!("{x}-{y}"));
-                std::fs::create_dir(map_tmp.join(&current_dir))
-                    .with_context(||
-                        format!("Failed to create temp map dir {}", &current_dir.display())
-                    )?;
-            }
-        }
+        let is_root = self.current_root == self.path;
+        let maps = if is_root {
+            self.root_maps.clone()
+        } else {
+            self.opt_maps.clone()
+        };
         let (has_aoc_dump, dump_static_pack) = if let Ok(aoc_main_field) =
                 self.dump.get_aoc_bytes_uncached("Aoc/0010/Pack/AocMainField.pack") {
                 (true, Sarc::new(aoc_main_field)
@@ -111,60 +103,32 @@ impl BnpConverter {
         diff.into_par_iter().map(|(hash, _)| -> Result<()> {
             let (section, load_type) = hash.split_once('_')
                 .ok_or(anyhow!("Bad map diff"))?;
-            let diff_file = format!("{section}/{section}_{load_type}.smubin");
-            let path = map_tmp.join(canon_rel.join(&diff_file));
-            match load_type {
-                "Dynamic" => {
-                    if self.current_root != self.path &&
-                        let root_path = self.path
-                            .join("map_tmp")
-                            .join(canon_rel)
-                            .join(&diff_file) &&
-                        root_path.exists() {
-                        std::fs::copy(&root_path, path)
-                            .map(|_| {})
-                            .with_context(|| format!("Failed to copy {hash} from root"))
-                    } else if has_aoc_dump {
-                        std::fs::write(
-                            path,
-                            self.dump.get_aoc_bytes_uncached(
-                                Path::new("Aoc/0010")
-                                    .join(canon_rel)
-                                    .join(&diff_file)
-                            ).with_context(|| format!("Could not find Aoc map file {hash}"))?
-                        ).with_context(|| format!("Failed to copy {hash} from dlc dump"))
-                    } else {
-                        std::fs::write(
-                            path,
-                            self.dump.get_bytes_uncached(canon_rel.join(&diff_file))
-                                .with_context(|| format!("Could not find base map file {hash}"))?
-                        ).with_context(|| format!("Failed to copy {hash} from base dump"))
-                    }
-                },
-                "Static" => {
-                    if self.current_root != self.path &&
-                        let root_path = self.path
-                            .join("map_tmp")
-                            .join(canon_rel)
-                            .join(&diff_file) &&
-                        root_path.exists() {
-                        std::fs::copy(&root_path, path)
-                            .map(|_| {})
-                            .with_context(|| format!("Failed to copy {hash} from root"))
-                    } else {
-                        std::fs::write(
-                            path,
-                            dump_static_pack.get(&canon_rel.join(&diff_file).to_string_lossy())
-                                .with_context(|| format!(
-                                    "Failed to extract {}",
-                                    canon_rel.join(&diff_file).display())
-                                )?
+            let canon = format!("Map/MainField/{section}/{section}_{load_type}.smubin");
+            if !is_root && let Some(root_data) = self.root_maps.get(&canon) {
+                maps.insert(canon, root_data.value().clone());
+            } else {
+                maps.insert(
+                    canon.clone(),
+                    match (load_type, has_aoc_dump) {
+                        ("Dynamic", true) => {
+                            self.dump.get_aoc_bytes_uncached(Path::new("Aoc/0010").join(&canon))
+                                .with_context(|| format!("Could not find Aoc map file {canon}"))?
+                        },
+                        ("Dynamic", false) => {
+                            self.dump.get_bytes_uncached(&canon)
+                                .with_context(|| format!("Could not find base map file {canon}"))?
+                        },
+                        ("Static", _) => {
+                            dump_static_pack.get(&canon)
+                                .with_context(|| format!("Failed to extract {canon}"))?
                                 .data
-                        ).with_context(|| format!("Failed to copy {hash} from dump"))
+                                .into()
+                        },
+                        _ => anyhow::bail!("Invalid hash: {hash}"),
                     }
-                },
-                _ => anyhow::bail!("Invalid hash: {}", hash),
+                );
             }
+            Ok(())
         })
         .collect::<Result<Vec<_>>>()?;
         Ok(())
@@ -175,24 +139,25 @@ impl BnpConverter {
         if !maps_path.exists() { return Ok(()) }
 
         log::debug!("Processing maps log");
-        let map_tmp = self.current_root.join("map_tmp").join("Map").join("MainField");
+        let maps = if self.current_root == self.path {
+            self.root_maps.clone()
+        } else {
+            self.opt_maps.clone()
+        };
         Byml::from_text(fs::read_to_string(maps_path)?)
             .context("Could not parse maps log")?
             .into_map()?
             .into_par_iter()
             .map(|(section, diff)| -> Result<()> {
-                let (square, load_type) = section.split_once('_')
-                    .ok_or(anyhow!("Bad map diff"))?;
-                let path = map_tmp
-                    .join(square)
-                    .join(format!("{square}_{load_type}.smubin"));
+                let square = section.split_once('_')
+                    .ok_or(anyhow!("Bad map diff"))?
+                    .0;
+                let canon = format!("Map/MainField/{square}/{section}.smubin");
                 let mut base = Byml::from_binary(
-                    decompress(
-                        std::fs::read(&path)
-                            .with_context(|| format!("Failed to read {}", path.display()))?
+                        decompress(maps.get(&canon).expect("Lost a map file?").value())
+                            .with_context(|| format!("Failed to decompress map {canon}"))?
                     )
-                    .with_context(|| format!("Failed to decompress map {}", path.display()))?
-                )?;
+                    .with_context(|| format!("Failed to read map {canon}"))?;
                 merge_map(&mut base, diff)
                     .with_context(||
                         if !self.dump.source().file_exists(Path::new("Pack/AocMainField.pack")) {
@@ -202,7 +167,7 @@ impl BnpConverter {
                             format!("Failed to rebuild {section}.")
                         }
                     )?;
-                fs::write(&path, compress(base.to_binary(self.platform.into())))?;
+                maps.insert(canon, compress(base.to_binary(self.platform.into())));
                 Ok(())
             })
             .collect::<Result<Vec<_>>>()?;
@@ -240,34 +205,33 @@ impl BnpConverter {
                 ret
             })
             .unwrap_or_else(|| SarcWriter::from_sarc(&dump_pack));
-        let map_tmp = self.current_root.join("map_tmp");
         let dynamic_prefix = if has_aoc_dump {
             self.current_root.join(self.aoc)
         } else {
             self.current_root.join(self.content)
         };
 
-        for x in 'A'..'K' {
-            for y in 1..9 {
-                let static_path = format!("Map/MainField/{x}-{y}/{x}-{y}_Static.smubin");
-                let stc = map_tmp.join(&static_path);
-                if stc.exists() {
-                    merged_pack.add_file(&static_path, std::fs::read(stc)?);
-                }
-                let dynamic_path = format!("Map/MainField/{x}-{y}/{x}-{y}_Dynamic.smubin");
-                let dynamic = map_tmp.join(&dynamic_path);
-                if dynamic.exists() {
-                    let out = dynamic_prefix.join(&dynamic_path);
-                    out.parent().iter().try_for_each(fs::create_dir_all)?;
-                    std::fs::copy(dynamic, out)?;
-                }
+        let maps = if self.current_root == self.path {
+            self.root_maps.clone()
+        } else {
+            self.opt_maps.clone()
+        };
+        for map in maps.iter() {
+            let canon = map.key();
+            // char 30 will always be S - Static - or D - Dynamic
+            if canon.chars().nth(30).expect("Infallible") == 'S' {
+                merged_pack.add_file(canon, map.value().clone());
+            } else {
+                let out = dynamic_prefix.join(canon);
+                out.parent().iter().try_for_each(fs::create_dir_all)?;
+                std::fs::write(out, map.value())?;
             }
         }
 
         dest_path.parent().iter().try_for_each(fs::create_dir_all)?;
         fs::write(dest_path, merged_pack.to_binary())?;
 
-        util::remove_dir_all(map_tmp).context("Failed to remove map_tmp")?;
+        maps.clear();
         Ok(())
     }
 }

--- a/crates/uk-manager/src/bnp/maps.rs
+++ b/crates/uk-manager/src/bnp/maps.rs
@@ -1,8 +1,7 @@
-use std::collections::BTreeMap;
-
+use std::path::Path;
+use anyhow::anyhow;
 use anyhow_ext::{Context, Result};
 use fs_err as fs;
-use join_str::jstr;
 use rayon::prelude::*;
 use roead::{
     byml::{Byml, Map},
@@ -10,9 +9,7 @@ use roead::{
     yaz0::{compress, decompress},
 };
 use rustc_hash::FxHashMap;
-use smartstring::alias::String;
-use split_iter::Splittable;
-
+use crate::util;
 use super::BnpConverter;
 
 fn merge_map(base: &mut Byml, diff: Byml) -> Result<()> {
@@ -61,12 +58,12 @@ fn merge_map(base: &mut Byml, diff: Byml) -> Result<()> {
         Ok(())
     }
 
-    if let (Some(Byml::Map(mut diff_objs)), Some(Byml::Array(ref mut base_objs))) =
+    if let (Some(Byml::Map(mut diff_objs)), Some(Byml::Array(base_objs))) =
         (diff.remove("Objs"), base.get_mut("Objs"))
     {
         merge_section(base_objs, &mut diff_objs)?;
     }
-    if let (Some(Byml::Map(mut diff_rails)), Some(Byml::Array(ref mut base_rails))) =
+    if let (Some(Byml::Map(mut diff_rails)), Some(Byml::Array(base_rails))) =
         (diff.remove("Rails"), base.get_mut("Rails"))
     {
         merge_section(base_rails, &mut diff_rails)?;
@@ -75,59 +72,202 @@ fn merge_map(base: &mut Byml, diff: Byml) -> Result<()> {
 }
 
 impl BnpConverter {
+    // Pull out all map files in a temp dir for handle_maps
+    // There's an insanely complicated set of circumstances
+    // for managing where the files should come from, for
+    // all the different combinations of circumstances, so
+    // sort that all out here and just have handle_maps use
+    // the state we've built.
+    pub fn set_up_temp_map_state(&self) -> Result<()> {
+        let maps_path = self.current_root.join("logs/map.yml");
+        if !maps_path.exists() { return Ok(()) }
+
+        let canon_rel = Path::new("Map/MainField");
+        let map_tmp = self.current_root.join("map_tmp");
+        std::fs::create_dir_all(map_tmp.join(canon_rel))
+            .context("Failed to create temp MainField dir")?;
+        for x in 'A'..'K' {
+            for y in 1..9 {
+                let current_dir = canon_rel.join(format!("{x}-{y}"));
+                std::fs::create_dir(map_tmp.join(&current_dir))
+                    .with_context(||
+                        format!("Failed to create temp map dir {}", &current_dir.display())
+                    )?;
+            }
+        }
+        let (has_aoc_dump, dump_static_pack) = if let Ok(aoc_main_field) =
+                self.dump.get_aoc_bytes_uncached("Aoc/0010/Pack/AocMainField.pack") {
+                (true, Sarc::new(aoc_main_field)
+                    .context("Could not read Pack/AocMainField.pack")?)
+            } else {
+                (false, Sarc::new(self.dump
+                    .get_bytes_uncached("Pack/TitleBG.pack")
+                    .context("Could not find map archive in dump")?)
+                    .context("Could not read Pack/TitleBG.pack")?)
+            };
+        let diff = Byml::from_text(fs::read_to_string(maps_path)?)
+            .context("Could not parse maps log")?
+            .into_map()?;
+        diff.into_par_iter().map(|(hash, _)| -> Result<()> {
+            let (section, load_type) = hash.split_once('_')
+                .ok_or(anyhow!("Bad map diff"))?;
+            let diff_file = format!("{section}/{section}_{load_type}.smubin");
+            let path = map_tmp.join(canon_rel.join(&diff_file));
+            match load_type {
+                "Dynamic" => {
+                    if self.current_root != self.path &&
+                        let root_path = self.path
+                            .join("map_tmp")
+                            .join(canon_rel)
+                            .join(&diff_file) &&
+                        root_path.exists() {
+                        std::fs::copy(&root_path, path)
+                            .map(|_| {})
+                            .with_context(|| format!("Failed to copy {hash} from root"))
+                    } else if has_aoc_dump {
+                        std::fs::write(
+                            path,
+                            self.dump.get_aoc_bytes_uncached(
+                                Path::new("Aoc/0010")
+                                    .join(canon_rel)
+                                    .join(&diff_file)
+                            ).with_context(|| format!("Could not find Aoc map file {hash}"))?
+                        ).with_context(|| format!("Failed to copy {hash} from dlc dump"))
+                    } else {
+                        std::fs::write(
+                            path,
+                            self.dump.get_bytes_uncached(canon_rel.join(&diff_file))
+                                .with_context(|| format!("Could not find base map file {hash}"))?
+                        ).with_context(|| format!("Failed to copy {hash} from base dump"))
+                    }
+                },
+                "Static" => {
+                    if self.current_root != self.path &&
+                        let root_path = self.path
+                            .join("map_tmp")
+                            .join(canon_rel)
+                            .join(&diff_file) &&
+                        root_path.exists() {
+                        std::fs::copy(&root_path, path)
+                            .map(|_| {})
+                            .with_context(|| format!("Failed to copy {hash} from root"))
+                    } else {
+                        std::fs::write(
+                            path,
+                            dump_static_pack.get(&canon_rel.join(&diff_file).to_string_lossy())
+                                .with_context(|| format!(
+                                    "Failed to extract {}",
+                                    canon_rel.join(&diff_file).display())
+                                )?
+                                .data
+                        ).with_context(|| format!("Failed to copy {hash} from dump"))
+                    }
+                },
+                _ => anyhow::bail!("Invalid hash: {}", hash),
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+        Ok(())
+    }
+
     pub fn handle_maps(&self) -> Result<()> {
         let maps_path = self.current_root.join("logs/map.yml");
-        if maps_path.exists() {
-            log::debug!("Processing maps log");
-            let diff = Byml::from_text(fs::read_to_string(maps_path)?)
-                .context("Could not parse maps log")?
-                .into_map()?;
-            let base_pack = Sarc::new(self.get_master_aoc_bytes("Pack/AocMainField.pack")?)
-                .context("Could not read Pack/AocMainField.pack")?;
-            let mut merged_pack = SarcWriter::from_sarc(&base_pack);
-            let (statics, dynamics) = diff
-                .into_par_iter()
-                .map(|(section, diff)| -> Result<(String, Vec<u8>)> {
-                    let parts = section.split('_').collect::<Vec<_>>();
-                    let path = jstr!("Map/MainField/{&parts[0]}/{&section}.smubin");
-                    if !parts.len() == 2 {
-                        anyhow::bail!("Bad map diff");
+        if !maps_path.exists() { return Ok(()) }
+
+        log::debug!("Processing maps log");
+        let map_tmp = self.current_root.join("map_tmp").join("Map").join("MainField");
+        Byml::from_text(fs::read_to_string(maps_path)?)
+            .context("Could not parse maps log")?
+            .into_map()?
+            .into_par_iter()
+            .map(|(section, diff)| -> Result<()> {
+                let (square, load_type) = section.split_once('_')
+                    .ok_or(anyhow!("Bad map diff"))?;
+                let path = map_tmp
+                    .join(square)
+                    .join(format!("{square}_{load_type}.smubin"));
+                let mut base = Byml::from_binary(
+                    decompress(
+                        std::fs::read(&path)
+                            .with_context(|| format!("Failed to read {}", path.display()))?
+                    )
+                    .with_context(|| format!("Failed to decompress map {}", path.display()))?
+                )?;
+                merge_map(&mut base, diff)
+                    .with_context(||
+                        if !self.dump.source().file_exists(Path::new("Pack/AocMainField.pack")) {
+                            format!("Failed to rebuild {section}. This map section *may* contain \
+                                edits to DLC data, and your DLC path is not set.")
+                        } else {
+                            format!("Failed to rebuild {section}.")
+                        }
+                    )?;
+                fs::write(&path, compress(base.to_binary(self.platform.into())))?;
+                Ok(())
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(())
+    }
+
+    pub fn clear_temp_map_state(&self) -> Result<()> {
+        let maps_path = self.current_root.join("logs/map.yml");
+        if !maps_path.exists() { return Ok(()) }
+
+        let has_aoc_dump = self.dump
+            .source()
+            .file_exists(Path::new("Pack/AocMainField.pack"));
+        let dest_path = self
+            .current_root
+            .join(if has_aoc_dump { self.aoc } else { self.content })
+            .join(if has_aoc_dump { "Pack/AocMainField.pack" } else { "Pack/TitleBG.pack" });
+        let root_pack = if let Ok(bytes) = std::fs::read(&dest_path) {
+            Sarc::new(bytes).ok()
+        } else {
+            None
+        };
+        let dump_pack = if has_aoc_dump {
+                Sarc::new(self.get_master_aoc_bytes("Pack/AocMainField.pack")?)?
+        } else {
+                Sarc::new(self.get_master_bytes("Pack/TitleBG.pack")?)?
+        };
+        let mut merged_pack = root_pack.map(|pack| {
+                let mut ret = SarcWriter::from_sarc(&pack);
+                for file in dump_pack.files() {
+                    if file.name.is_some_and(|name| !ret.files.contains_key(name)) {
+                        ret.add_file(file.unwrap_name(), file.data);
                     }
-                    let mut base = Byml::from_binary(decompress(
-                        base_pack
-                            .get_data(&path)
-                            .map(|d| d.to_vec())
-                            .with_context(|| jstr!("AocMainField.pack missing map {&path}"))
-                            .or_else(|e| {
-                                self.get_master_aoc_bytes(&path)
-                                    .context(e)
-                                    .with_context(|| jstr!("Game dump missing map {&path}"))
-                            })?,
-                    )?)?;
-                    merge_map(&mut base, diff)
-                        .with_context(|| jstr!("Failed to rebuild {&section}"))?;
-                    Ok((path.into(), compress(base.to_binary(self.platform.into()))))
-                })
-                .collect::<Result<BTreeMap<String, Vec<u8>>>>()?
-                .into_iter()
-                .split(|(k, _)| k.ends_with("Dynamic.smubin"));
-            merged_pack.add_files(statics);
-            dynamics
-                .collect::<BTreeMap<String, Vec<u8>>>()
-                .into_par_iter()
-                .try_for_each(|(path, data)| -> Result<()> {
-                    let dest_path = self.current_root.join(self.aoc).join(path.as_str());
-                    dest_path.parent().iter().try_for_each(fs::create_dir_all)?;
-                    fs::write(dest_path, data)?;
-                    Ok(())
-                })?;
-            let dest_path = self
-                .current_root
-                .join(self.aoc)
-                .join("Pack/AocMainField.pack");
-            dest_path.parent().iter().try_for_each(fs::create_dir_all)?;
-            fs::write(dest_path, merged_pack.to_binary())?;
+                }
+                ret
+            })
+            .unwrap_or_else(|| SarcWriter::from_sarc(&dump_pack));
+        let map_tmp = self.current_root.join("map_tmp");
+        let dynamic_prefix = if has_aoc_dump {
+            self.current_root.join(self.aoc)
+        } else {
+            self.current_root.join(self.content)
+        };
+
+        for x in 'A'..'K' {
+            for y in 1..9 {
+                let static_path = format!("Map/MainField/{x}-{y}/{x}-{y}_Static.smubin");
+                let stc = map_tmp.join(&static_path);
+                if stc.exists() {
+                    merged_pack.add_file(&static_path, std::fs::read(stc)?);
+                }
+                let dynamic_path = format!("Map/MainField/{x}-{y}/{x}-{y}_Dynamic.smubin");
+                let dynamic = map_tmp.join(&dynamic_path);
+                if dynamic.exists() {
+                    let out = dynamic_prefix.join(&dynamic_path);
+                    out.parent().iter().try_for_each(fs::create_dir_all)?;
+                    std::fs::copy(dynamic, out)?;
+                }
+            }
         }
+
+        dest_path.parent().iter().try_for_each(fs::create_dir_all)?;
+        fs::write(dest_path, merged_pack.to_binary())?;
+
+        util::remove_dir_all(map_tmp).context("Failed to remove map_tmp")?;
         Ok(())
     }
 }


### PR DESCRIPTION
Adds experimental support for converting map-mod bnps when dlc is not installed

Addresses and closes #300 