### PR TITLE
Change chapter list items display to block

### DIFF
--- a/book/theme/css/chrome.css
+++ b/book/theme/css/chrome.css
@@ -425,7 +425,7 @@ ul#searchresults span.teaser em {
 }
 
 .chapter li {
-    display: flex;
+    display: block;
     color: var(--sidebar-non-existant);
 }
 .chapter li a {


### PR DESCRIPTION
fixed "The Book" 's layout with the chapters 3.1 and 3.2 displaying in a 2nd column of the sidebar.
i checked firefox, chrome and edge.