### PR TITLE
fix: correct 'occured' to 'occurred' typo in user-facing error message

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -433,7 +433,7 @@ impl App {
                         "{}",
                         e.downcast::<String>().unwrap_or_else(|_| {
                             Box::new(
-                                "An unknown error occured, check the log for possible details."
+                                "An unknown error occurred, check the log for possible details."
                                     .to_string(),
                             )
                         })


### PR DESCRIPTION
Corrects spelling error in error message shown to users via GUI when an unknown error occurs.

One instance corrected: `src/gui.rs` line 436.

GH007 compliant: commit uses noreply email 166608075+Jah-yee@users.noreply.github.com.